### PR TITLE
Improve world size and gameplay balance

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -7,9 +7,21 @@ const app = new PIXI.Application({
 });
 document.body.appendChild(app.view);
 
+// Размер игрового мира
+const WORLD_SIZE = 5000;
+
 // Контейнер мира, в нем камера и всё остальное
 const world = new PIXI.Container();
 app.stage.addChild(world);
+
+// Граница мира для наглядности
+const border = new PIXI.Graphics();
+border.lineStyle(4, 0xffffff);
+border.drawRect(-WORLD_SIZE / 2, -WORLD_SIZE / 2, WORLD_SIZE, WORLD_SIZE);
+world.addChild(border);
+
+// Ограничение роста игрока
+const MAX_PLAYER_SIZE = 250;
 
 // Игрок: зелёный квадрат
 const player = new PIXI.Graphics();
@@ -21,19 +33,31 @@ player.y = 0;
 player.size = 50;
 world.addChild(player);
 
-// Еда: 100 точек в большом мире
+// Еда: точки, разбросанные по миру
 const foods = [];
-const FOOD_COUNT = 100;
+const FOOD_COUNT = 250;
 for (let i = 0; i < FOOD_COUNT; i++) {
+  spawnFood();
+}
+
+// Функция создания еды в случайной точке
+function spawnFood() {
   const food = new PIXI.Graphics();
   food.beginFill(0xffcc00);
   food.drawCircle(0, 0, 5);
   food.endFill();
-  food.x = (Math.random() - 0.5) * 10000;
-  food.y = (Math.random() - 0.5) * 10000;
+  food.x = (Math.random() - 0.5) * WORLD_SIZE;
+  food.y = (Math.random() - 0.5) * WORLD_SIZE;
   world.addChild(food);
   foods.push(food);
 }
+
+// Респавн еды каждые 5 секунд
+setInterval(() => {
+  for (let i = 0; i < 3; i++) {
+    spawnFood();
+  }
+}, 5000);
 
 // Управление мышью
 let targetX = 0;
@@ -62,7 +86,9 @@ app.ticker.add((delta) => {
     if (dist < player.size / 2 + 5) {
       world.removeChild(f);
       foods.splice(i, 1);
-      player.size += 2;
+      if (player.size < MAX_PLAYER_SIZE) {
+        player.size = Math.min(player.size + 1, MAX_PLAYER_SIZE);
+      }
       player.clear();
       player.beginFill(0x00ff00);
       player.drawRect(-player.size / 2, -player.size / 2, player.size, player.size);


### PR DESCRIPTION
## Summary
- shrink world to 5000x5000 and draw visible border
- spawn more initial food and respawn food over time
- limit player growth and slow size increase

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686053085cf8832cb208bae2666efef1