### PR TITLE
Implement PvE and PvP modes

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -7,6 +7,10 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
+  <div id="menu">
+    <button id="pveBtn">PvE</button>
+    <button id="pvpBtn">PvP</button>
+  </div>
   <!-- Локальная копия PixiJS, чтобы игра запускалась без доступа к CDN -->
   <script src="pixi.min.js"></script>
   <script src="/socket.io/socket.io.js"></script>

--- a/client/main.js
+++ b/client/main.js
@@ -1,46 +1,88 @@
-const app = new PIXI.Application({
-  width: window.innerWidth,
-  height: window.innerHeight,
-  backgroundColor: 0x222222,
-  resolution: window.devicePixelRatio || 1,
-  autoDensity: true
-});
-document.body.appendChild(app.view);
+const menu = document.getElementById('menu');
+const pveBtn = document.getElementById('pveBtn');
+const pvpBtn = document.getElementById('pvpBtn');
 
-// Размер игрового мира
+let mode = null; // 'pve' or 'pvp'
+let socket;
+
+let app, world, player, foods, bots = [], remotePlayers = {};
+
 const WORLD_SIZE = 5000;
-
-// Контейнер мира, в нем камера и всё остальное
-const world = new PIXI.Container();
-app.stage.addChild(world);
-
-// Граница мира для наглядности
-const border = new PIXI.Graphics();
-border.lineStyle(4, 0xffffff);
-border.drawRect(-WORLD_SIZE / 2, -WORLD_SIZE / 2, WORLD_SIZE, WORLD_SIZE);
-world.addChild(border);
-
-// Ограничение роста игрока
+const FOOD_COUNT = 250;
 const MAX_PLAYER_SIZE = 250;
 
-// Игрок: зелёный квадрат
-const player = new PIXI.Graphics();
-player.beginFill(0x00ff00);
-player.drawRect(-25, -25, 50, 50);
-player.endFill();
-player.x = 0;
-player.y = 0;
-player.size = 50;
-world.addChild(player);
+pveBtn.addEventListener('click', () => startGame('pve'));
+pvpBtn.addEventListener('click', () => startGame('pvp'));
 
-// Еда: точки, разбросанные по миру
-const foods = [];
-const FOOD_COUNT = 250;
-for (let i = 0; i < FOOD_COUNT; i++) {
-  spawnFood();
+function startGame(selected) {
+  mode = selected;
+  menu.style.display = 'none';
+  initGame();
+  if (mode === 'pve') {
+    createBots(9);
+  } else if (mode === 'pvp') {
+    setupSocket();
+  }
 }
 
-// Функция создания еды в случайной точке
+function initGame() {
+  app = new PIXI.Application({
+    width: window.innerWidth,
+    height: window.innerHeight,
+    backgroundColor: 0x222222,
+    resolution: window.devicePixelRatio || 1,
+    autoDensity: true
+  });
+  document.body.appendChild(app.view);
+
+  world = new PIXI.Container();
+  app.stage.addChild(world);
+
+  const border = new PIXI.Graphics();
+  border.lineStyle(4, 0xffffff);
+  border.drawRect(-WORLD_SIZE / 2, -WORLD_SIZE / 2, WORLD_SIZE, WORLD_SIZE);
+  world.addChild(border);
+
+  player = createCube(0x00ff00, 50);
+  player.x = 0;
+  player.y = 0;
+  player.size = 50;
+  world.addChild(player);
+
+  foods = [];
+  for (let i = 0; i < FOOD_COUNT; i++) {
+    spawnFood();
+  }
+
+  setInterval(() => {
+    for (let i = 0; i < 3; i++) {
+      spawnFood();
+    }
+  }, 5000);
+
+  let targetX = 0;
+  let targetY = 0;
+  window.addEventListener('mousemove', (e) => {
+    targetX = e.clientX - app.screen.width / 2;
+    targetY = e.clientY - app.screen.height / 2;
+  });
+  window.addEventListener('touchmove', (e) => {
+    const touch = e.touches[0];
+    targetX = touch.clientX - app.screen.width / 2;
+    targetY = touch.clientY - app.screen.height / 2;
+  });
+
+  app.ticker.add((delta) => gameLoop(delta, targetX, targetY));
+}
+
+function createCube(color, size) {
+  const g = new PIXI.Graphics();
+  g.beginFill(color);
+  g.drawRect(-size / 2, -size / 2, size, size);
+  g.endFill();
+  return g;
+}
+
 function spawnFood() {
   const food = new PIXI.Graphics();
   food.beginFill(0xffcc00);
@@ -52,24 +94,8 @@ function spawnFood() {
   foods.push(food);
 }
 
-// Респавн еды каждые 5 секунд
-setInterval(() => {
-  for (let i = 0; i < 3; i++) {
-    spawnFood();
-  }
-}, 5000);
-
-// Управление мышью
-let targetX = 0;
-let targetY = 0;
-window.addEventListener("mousemove", (e) => {
-  targetX = e.clientX - app.screen.width / 2;
-  targetY = e.clientY - app.screen.height / 2;
-});
-
-// Игровой цикл
-app.ticker.add((delta) => {
-  // Движение к указателю
+function gameLoop(delta, targetX, targetY) {
+  // движение игрока
   const dx = targetX;
   const dy = targetY;
   const len = Math.sqrt(dx * dx + dy * dy);
@@ -79,24 +105,121 @@ app.ticker.add((delta) => {
     player.y += (dy / len) * speed * delta;
   }
 
-  // Сбор еды
-  for (let i = foods.length - 1; i >= 0; i--) {
-    const f = foods[i];
-    const dist = Math.hypot(f.x - player.x, f.y - player.y);
-    if (dist < player.size / 2 + 5) {
-      world.removeChild(f);
-      foods.splice(i, 1);
-      if (player.size < MAX_PLAYER_SIZE) {
-        player.size = Math.min(player.size + 1, MAX_PLAYER_SIZE);
-      }
-      player.clear();
-      player.beginFill(0x00ff00);
-      player.drawRect(-player.size / 2, -player.size / 2, player.size, player.size);
-      player.endFill();
-    }
+  collectFood(player);
+
+  if (mode === 'pve') {
+    updateBots(delta);
+  } else if (mode === 'pvp' && socket) {
+    socket.emit('update', { x: player.x, y: player.y, size: player.size });
   }
 
-  // Камера
   world.x = app.screen.width / 2 - player.x;
   world.y = app.screen.height / 2 - player.y;
-});
+}
+
+function collectFood(obj) {
+  for (let i = foods.length - 1; i >= 0; i--) {
+    const f = foods[i];
+    const dist = Math.hypot(f.x - obj.x, f.y - obj.y);
+    if (dist < obj.size / 2 + 5) {
+      world.removeChild(f);
+      foods.splice(i, 1);
+      if (obj.size < MAX_PLAYER_SIZE) {
+        obj.size = Math.min(obj.size + 1, MAX_PLAYER_SIZE);
+      }
+      obj.clear();
+      obj.beginFill(obj === player ? 0x00ff00 : 0xff0000);
+      obj.drawRect(-obj.size / 2, -obj.size / 2, obj.size, obj.size);
+      obj.endFill();
+    }
+  }
+}
+
+function createBots(count) {
+  for (let i = 0; i < count; i++) {
+    const bot = createCube(0xff0000, 50);
+    bot.x = (Math.random() - 0.5) * WORLD_SIZE;
+    bot.y = (Math.random() - 0.5) * WORLD_SIZE;
+    bot.size = 50;
+    bot.target = null;
+    bots.push(bot);
+    world.addChild(bot);
+  }
+}
+
+function updateBots(delta) {
+  for (const bot of bots) {
+    if (!bot.target || !foods.includes(bot.target)) {
+      let min = Infinity;
+      for (const f of foods) {
+        const d = Math.hypot(f.x - bot.x, f.y - bot.y);
+        if (d < min) {
+          min = d;
+          bot.target = f;
+        }
+      }
+    }
+    if (bot.target) {
+      const dx = bot.target.x - bot.x;
+      const dy = bot.target.y - bot.y;
+      const len = Math.sqrt(dx * dx + dy * dy);
+      if (len > 0) {
+        const speed = 2;
+        bot.x += (dx / len) * speed * delta;
+        bot.y += (dy / len) * speed * delta;
+      }
+    }
+    collectFood(bot);
+  }
+}
+
+function setupSocket() {
+  socket = io();
+  socket.on('connect', () => {
+    socket.emit('join-room');
+  });
+
+  socket.on('current-players', (ids) => {
+    ids.forEach((id) => createRemotePlayer(id));
+  });
+
+  socket.on('player-joined', (id) => {
+    createRemotePlayer(id);
+  });
+
+  socket.on('player-left', (id) => {
+    removeRemotePlayer(id);
+  });
+
+  socket.on('player-update', (data) => {
+    const rp = remotePlayers[data.id];
+    if (rp) {
+      rp.x = data.x;
+      rp.y = data.y;
+      if (rp.size !== data.size) {
+        rp.size = data.size;
+        rp.clear();
+        rp.beginFill(0x0000ff);
+        rp.drawRect(-rp.size / 2, -rp.size / 2, rp.size, rp.size);
+        rp.endFill();
+      }
+    }
+  });
+}
+
+function createRemotePlayer(id) {
+  if (remotePlayers[id]) return;
+  const g = createCube(0x0000ff, 50);
+  g.size = 50;
+  g.x = 0;
+  g.y = 0;
+  remotePlayers[id] = g;
+  world.addChild(g);
+}
+
+function removeRemotePlayer(id) {
+  const g = remotePlayers[id];
+  if (!g) return;
+  world.removeChild(g);
+  delete remotePlayers[id];
+}

--- a/client/style.css
+++ b/client/style.css
@@ -6,3 +6,19 @@ body {
 canvas {
   display: block;
 }
+
+#menu {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  z-index: 10;
+}
+
+#menu button {
+  font-size: 1.2em;
+  padding: 10px 20px;
+}

--- a/server.js
+++ b/server.js
@@ -10,12 +10,62 @@ const PORT = 3000;
 
 app.use(express.static("client"));
 
+// Максимальное число игроков в комнате
+const MAX_PLAYERS = 10;
+
+// Информация о комнатах: { roomId: Set(socket.id) }
+const rooms = {};
+
+function findRoom() {
+  for (const [id, players] of Object.entries(rooms)) {
+    if (players.size < MAX_PLAYERS) {
+      return id;
+    }
+  }
+  // Создание новой комнаты
+  const newId = Math.random().toString(36).substr(2, 9);
+  rooms[newId] = new Set();
+  return newId;
+}
+
 io.on("connection", (socket) => {
   console.log("Игрок подключился:", socket.id);
 
-  // Тут будут события позже
+  socket.on("join-room", () => {
+    const roomId = findRoom();
+    socket.join(roomId);
+    socket.roomId = roomId;
+    rooms[roomId].add(socket.id);
+
+    // Отправить новому игроку уже находящихся в комнате
+    const others = Array.from(rooms[roomId]).filter((id) => id !== socket.id);
+    socket.emit("current-players", others);
+
+    // Уведомить других игроков
+    socket.to(roomId).emit("player-joined", socket.id);
+    console.log(`Игрок ${socket.id} в комнате ${roomId}`);
+  });
+
+  socket.on("update", (data) => {
+    if (!socket.roomId) return;
+    socket.to(socket.roomId).emit("player-update", {
+      id: socket.id,
+      x: data.x,
+      y: data.y,
+      size: data.size,
+    });
+  });
+
   socket.on("disconnect", () => {
     console.log("Игрок отключился:", socket.id);
+    const roomId = socket.roomId;
+    if (roomId && rooms[roomId]) {
+      rooms[roomId].delete(socket.id);
+      socket.to(roomId).emit("player-left", socket.id);
+      if (rooms[roomId].size === 0) {
+        delete rooms[roomId];
+      }
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- add rooms and player sync on the server
- add start menu with PvE/PvP buttons
- implement bots for PvE mode
- implement Socket.IO client for PvP mode
- style the menu for mobile screens

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6860585fcb78832ca30709de9db4fe5a