### PR TITLE
Fix collision removal bug

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -514,8 +514,11 @@ function handleCollisions(event) {
 
 function collideCubes(c1, c2) {
   if (!c1 || !c2 || !c1.body || !c2.body) return;
-  removeCubeBlocks(c1, 1, c2.body.position);
-  removeCubeBlocks(c2, 1, c1.body.position);
+  // capture positions before any cube might lose its physics body
+  const pos1 = { x: c1.body.position.x, y: c1.body.position.y };
+  const pos2 = { x: c2.body.position.x, y: c2.body.position.y };
+  removeCubeBlocks(c1, 1, pos2);
+  removeCubeBlocks(c2, 1, pos1);
 }
 
 function createFragmentFromCollision(size, pos, from, color) {


### PR DESCRIPTION
## Summary
- ensure cube positions are captured before blocks are removed

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68608f55f5b4832c9f0efcf01fc669c1