### PR TITLE
Fix food sprite size

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -44,6 +44,7 @@ const WORLD_SIZE = 5000;
 const FOOD_COUNT = 250;
 const MAX_PLAYER_SIZE = 250;
 const BLOCK_SIZE = 35;
+const FOOD_SIZE = 25;
 let cubeIdCounter = 0;
 const HIT_COOLDOWN = 500; // ms between damage from the same cube
 const SPEED_BASE = 8;
@@ -378,7 +379,7 @@ function spawnFood() {
   const styleNames = Object.keys(STYLES);
   const style = STYLES[styleNames[Math.floor(Math.random() * styleNames.length)]];
   const food = new PIXI.Sprite(PIXI.Texture.from(style.path));
-  const size = BLOCK_SIZE;
+  const size = FOOD_SIZE;
   food.width = size;
   food.height = size;
   food.x = (Math.random() - 0.5) * WORLD_SIZE;


### PR DESCRIPTION
## Summary
- add constant `FOOD_SIZE`
- size food sprites using `FOOD_SIZE` to keep them 25x25

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6860e7722fc0832cbbed16d1df8734b5