### PR TITLE
Fix snake mode particle collection

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -601,7 +601,7 @@ function collectParticle(cube, p) {
   if (p.pickupCooldown && Date.now() < p.pickupCooldown) return;
   if (p.enemyCooldown && p.ownerId && p.ownerId !== cube.cid && Date.now() < p.enemyCooldown) return;
   if (p.forbidOwner && p.sourceId === cube.cid) return;
-  if (!cube.body && cube.grid.length === 0) return;
+  if (!cube.body && cube.grid.length === 0 && !cube.isSnake && !(cube.parentCube && cube.parentCube.isSnake)) return;
 
   p.collected = true;
 
@@ -724,11 +724,12 @@ function processEating(delta) {
 
 function checkFoodCollisions() {
   for (const c of cubes) {
-    if (!c.body) continue;
+    if (!c.body && !c.isSnake && !(c.parentCube && c.parentCube.isSnake)) continue;
+    const cPos = c.body ? c.body.position : { x: c.x, y: c.y };
     for (const f of foods) {
       if (!f.body || f.collected) continue;
       const fSize = f.massSize || FOOD_SIZE;
-      const dist = Vector.magnitude(Vector.sub(c.body.position, f.body.position));
+      const dist = Vector.magnitude(Vector.sub(cPos, f.body.position));
       if (dist < (c.size + fSize) / 2) {
         collectParticle(c, f);
       }


### PR DESCRIPTION
## Summary
- allow collecting food/fragments while in snake mode, even without body
- detect food collisions for bodyless snake heads/segments

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68634f3aa058832c8012f151f6ba55a7